### PR TITLE
refactor(ndt7): avoid counterflow panic on closed channel

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: test
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+jobs:
+  build_and_run_tests:
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      matrix:
+        go: [ "1.18.2" ]
+        os: [ "ubuntu-20.04", "windows-2019", "macos-10.15" ]
+    steps:
+      - uses: magnetikonline/action-golang-cache@v2
+        with:
+          go-version: "${{ matrix.go }}"
+          cache-key-suffix: "-coverage-${{ matrix.go }}"
+      - uses: actions/checkout@v2
+      - run: go build -v ./...
+      - run: go test -race ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/msak-client
+/msak-server

--- a/client/client.go
+++ b/client/client.go
@@ -110,7 +110,7 @@ func (r *Client) Receive(ctx context.Context) {
 		rtx.Must(err, "Could not write aggregate throughput to file")
 
 		for i, result := range results {
-			// Get UUID from the latest measurement
+			// Get UUID from the last measurement.
 			if len(result.Download.ClientMeasurements) == 0 {
 				fmt.Printf("Cannot get UUID from stream %d, skipping\n", i)
 				continue
@@ -142,7 +142,11 @@ func (r *Client) run(wg *sync.WaitGroup, ctx context.Context, measurements chan 
 	if conn, err = r.dialer(ctx, r.url); err != nil {
 		rtx.Must(err, "download dialer")
 	}
-	if err := ndt7.Receiver(ctx, measurements, conn); err != nil {
+	connInfo := &persistence.ConnectionInfo{
+		Server: conn.RemoteAddr().String(),
+		Client: conn.LocalAddr().String(),
+	}
+	if err := ndt7.Receiver(ctx, connInfo, measurements, conn); err != nil {
 		rtx.Must(err, "download")
 	}
 }

--- a/cmd/msak-server/main.go
+++ b/cmd/msak-server/main.go
@@ -4,9 +4,12 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 
+	"github.com/gorilla/websocket"
 	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/uuid"
 	"github.com/robertodauria/msak/internal"
 	"github.com/robertodauria/msak/internal/persistence"
 	"github.com/robertodauria/msak/ndt7"
@@ -17,7 +20,7 @@ var flagEndpointCleartext = flag.String("listen", ":8080", "Listen address/port 
 func main() {
 	flag.Parse()
 
-	// The ndt7 listener serving up NDT7 tests, likely on standard ports.
+	// The ndt7 listener serving up ndt7 tests, likely on standard ports.
 	ndt7Mux := http.NewServeMux()
 	ndt7Mux.Handle(internal.DownloadPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var cc string
@@ -37,7 +40,8 @@ func main() {
 					fmt.Printf("Download rate: %v\n", rate)
 				}
 			}()
-			err := ndt7.Sender(r.Context(), conn, measurements, cc)
+			connInfo := getConnInfo(conn)
+			err = ndt7.Sender(r.Context(), conn, connInfo, measurements, cc)
 			if err != nil {
 				fmt.Println(err)
 			}
@@ -52,7 +56,8 @@ func main() {
 					fmt.Printf("Upload rate: %v\n", rate)
 				}
 			}()
-			err := ndt7.Receiver(r.Context(), measurements, conn)
+			connInfo := getConnInfo(conn)
+			err := ndt7.Receiver(r.Context(), connInfo, measurements, conn)
 			if err != nil {
 				fmt.Println(err)
 			}
@@ -61,4 +66,17 @@ func main() {
 
 	log.Println("About to listen for ndt7 cleartext tests on " + *flagEndpointCleartext)
 	rtx.Must(http.ListenAndServe(*flagEndpointCleartext, ndt7Mux), "Could not start ndt7 cleartext server")
+}
+
+// Return a ConnectionInfo struct for the given websocket connection.
+func getConnInfo(conn *websocket.Conn) *persistence.ConnectionInfo {
+	tcpconn := conn.UnderlyingConn().(*net.TCPConn)
+	// Get UUID for this TCP flow.
+	uuid, err := uuid.FromTCPConn(tcpconn)
+	rtx.Must(err, "Failed to get UUID for websocket connection")
+	return &persistence.ConnectionInfo{
+		UUID:   uuid,
+		Client: conn.RemoteAddr().String(),
+		Server: conn.RemoteAddr().String(),
+	}
 }

--- a/cmd/msak-server/main.go
+++ b/cmd/msak-server/main.go
@@ -29,7 +29,8 @@ func main() {
 			cc = cch
 		}
 		if conn, err := ndt7.Upgrade(w, r); err == nil {
-			measurements := make(chan persistence.Measurement)
+			const buffersize = 64 // the emitter will not wait for us
+			measurements := make(chan persistence.Measurement, buffersize)
 			go func() {
 				for m := range measurements {
 					rate := float64(m.AppInfo.NumBytes) / float64(m.AppInfo.ElapsedTime) * 8

--- a/internal/congestion/congestion_stub.go
+++ b/internal/congestion/congestion_stub.go
@@ -9,7 +9,7 @@ import (
 	"github.com/m-lab/tcp-info/inetdiag"
 )
 
-func set(*os.File) error {
+func set(*os.File, string) error {
 	return ErrNoSupport
 }
 

--- a/internal/tcpinfox/tcpinfox_stub.go
+++ b/internal/tcpinfox/tcpinfox_stub.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package tcpinfox


### PR DESCRIPTION
This diff defines a protocol for shutting down the sender where we close the conn to signal goroutines we're done, then we wait for them to join using a waitgroup, and only at this point we close the channel.

Additionally, reckon that the counterflow reader may block writing on a channel and change the write pattern to be nonblocking and introduce a generous buffer to allow for writing without losing data in normal conditions.

While there:

1. introduce a .gitignore file

2. propose an even clearer concurrency pattern

3. fix the build for macOS

4. introduce smoke testing at github